### PR TITLE
添加 Docker 部署支持

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM nginx:alpine
+MAINTAINER bdbai <htbai1998m@hotmail.com>
+
+RUN apk --update add python3 python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev \
+    && cp /lib/libz.so /usr/lib/libz.so \
+    && python3 -m ensurepip \
+    && pip3 install uwsgi \
+    && mkdir /var/log/uwsgi
+
+ADD . /app
+WORKDIR /app
+
+RUN pip3 install -r requirements.txt \
+    && chmod +x docker/start.sh \
+    && cp docker/nginx.conf /etc/nginx/nginx.conf \
+    && apk del python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev
+
+EXPOSE 80
+CMD ["./docker/start.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:alpine
 MAINTAINER bdbai <htbai1998m@hotmail.com>
 
-RUN apk --update add python3 python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev \
+RUN apk --no-cache --update add python3 python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev \
     && cp /lib/libz.so /usr/lib/libz.so \
     && python3 -m ensurepip \
     && pip3 install uwsgi \
@@ -12,8 +12,7 @@ WORKDIR /app
 
 RUN pip3 install -r requirements.txt \
     && chmod +x docker/start.sh \
-    && cp docker/nginx.conf /etc/nginx/nginx.conf \
-    && apk del python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev
+    && cp docker/nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80
 CMD ["./docker/start.sh"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,32 @@
+worker_processes  1;
+error_log  /var/log/nginx/error.log  error;
+events {
+    worker_connections  1024;
+    use epoll;
+}
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log  /var/log/nginx/access.log  main;
+    sendfile        on;
+    keepalive_timeout  65;
+    #gzip  on;
+    server {
+      	listen 80;
+      	server_name localhost;
+      	location / {
+      		uwsgi_pass 127.0.0.1:4000;
+      		include uwsgi_params;
+      	}
+      	location ~ ^/static/usera {
+      		root /app/usera;
+      	}
+      	location ~ ^/static/blog {
+      		root /app/blog;
+      	}
+    }
+}
+

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+python3 manage.py makemigrations
+python3 manage.py migrate
+
+uwsgi --ini ./docker/uwsgi.ini &
+nginx -g 'daemon off;'

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -1,0 +1,9 @@
+[uwsgi]
+chdir=/app
+socket=127.0.0.1:4000
+module=blog_project.wsgi:application
+master=True
+pidfile=/tmp/project-master.pid
+vacuum=True
+max-requests=5000
+# daemonize=/var/log/uwsgi/blog_project.log


### PR DESCRIPTION
Docker 可以快速地在生产机器上部署应用，免去了一次次配置环境的麻烦。这个 Docker 配置基于一个小型 Linux 镜像 [`Alpine`](https://hub.docker.com/_/alpine/) 构造，使用 `NGINX` + `uWSGI` 提供 Web 服务。目前的 Python 版本为 `3.5.1`。

## 本地启动
__不要使用 Docker 环境来调试你的应用。__

以代码根目录为构建上下文，让 Docker 根据 `docker/Dockerfile` 来构建镜像：
```bash
cd DjangoBlog
docker build -t 'djangoblog' -f docker/Dockerfile . # djangoblog 代表你的镜像名
```
由于某些众所周知的原因，构建会比较缓慢。可以通过 [DaoCloud](https://daocloud.io/) 提供的[在线构建服务](http://docs.daocloud.io/ci-image-build/start-ci-and-build)完成构建并 pull 到本地。

接下来启动一个 Docker 容器来运行我们的镜像，使之以 daemon 模式在后台运行，并将容器内部暴露的 80 端口映射到本机的 8080 端口上：
```bash
docker run --name 'myblog' -d -p 8080:80 djangoblog # myblog 代表新的容器名
```
此时用你的浏览器打开 `http://localhost:8080` 访问即可。

回收这个容器：
```bash
docker kill myblog # 停止容器
docker rm myblog # 删除容器
```

## 在线演示
我在 [DaoCloud](https://daocloud.io) 上部署了一个临时的演示容器，并非生产环境。稍后它将被删除。
[http://bdbai-djbg.daoapp.io/](http://bdbai-djbg.daoapp.io/)

## 不足之处
- 数据管理
Docker 容器本身被设计为无状态的，因此数据应通过数据卷的方式挂载于容器外。而目前我们使用数据库是 `SQLite`，暂时简单处理，即数据库文件直接放置在容器内。

- 进程管理
`uWSGI` 作为 `NGINX` 的 uwsgi 后端，一旦进程挂掉就会出现 502，因此需要一个进程管理器来确保 `uWSGI` 始终可用。这个以后再补上吧。
