### PR TITLE
改进的 Docker 和部署配置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ ENV/
 # Pycharm settings
 .idea
 
+# Collected static files
+/static

--- a/blog_project/settings.py
+++ b/blog_project/settings.py
@@ -84,7 +84,7 @@ WSGI_APPLICATION = 'blog_project.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3') if os.getenv('DATA_PATH') is None else os.getenv('DATA_PATH'),
     }
 }
 
@@ -122,8 +122,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
+STATIC_ROOT = BASE_DIR + '/static'
 STATIC_URL = '/static/'
-STATICFILES = [os.path.join(BASE_DIR, 'blog/static'), os.path.join(BASE_DIR, 'usera/static'),
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'blog/static'), os.path.join(BASE_DIR, 'usera/static'),
                os.path.join(BASE_DIR, 'community/static')]
 
 AUTH_USER_MODEL = 'usera.ForumUser'

--- a/blog_project/urls.py
+++ b/blog_project/urls.py
@@ -14,12 +14,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 from django.conf.urls import url, include
+from django.conf.urls.static import static
 from django.contrib import admin
 from blog import views
+from blog_project import settings
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'', include('blog.urls', namespace='blog', app_name='blog')),
     url(r'', include('usera.urls', namespace='usera', app_name='usera')),
     url(r'', include('community.urls', namespace='community', app_name='community'))
-]
+] + static(settings.STATIC_URL, document_root = settings.STATIC_ROOT )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,20 @@
-FROM nginx:alpine
+FROM alpine
 MAINTAINER bdbai <htbai1998m@hotmail.com>
 
-RUN apk --no-cache --update add python3 python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev \
-    && cp /lib/libz.so /usr/lib/libz.so \
-    && python3 -m ensurepip \
-    && pip3 install uwsgi \
-    && mkdir /var/log/uwsgi
-
-ADD . /app
+ADD ./requirements.txt /app/requirements.txt
 WORKDIR /app
 
-RUN pip3 install -r requirements.txt \
-    && chmod +x docker/start.sh \
-    && cp docker/nginx.conf /etc/nginx/nginx.conf
+RUN apk --no-cache --update add python3 libjpeg-turbo python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev \
+    && cp /lib/libz.so /usr/lib/libz.so \
+    && python3 -m ensurepip --upgrade\
+    && pip3 install gunicorn \
+    && pip3 install -r requirements.txt \
+    && apk del python3-dev build-base linux-headers libjpeg-turbo-dev zlib-dev
 
-EXPOSE 80
-CMD ["./docker/start.sh"]
+ENV DATA_PATH /var/data/blog_project/db.sqlite3
+VOLUME ["/var/data/blog_project"]
+EXPOSE 4000
+CMD ["/bin/sh", "./docker/start.sh"]
+
+ADD . /app
+

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-python3 manage.py makemigrations
-python3 manage.py migrate
+python3 manage.py makemigrations --noinput
+python3 manage.py migrate --noinput
+python3 manage.py collectstatic --noinput > /dev/null
 
-uwsgi --ini ./docker/uwsgi.ini &
-nginx -g 'daemon off;'
+gunicorn -b 0.0.0.0:4000 blog_project.wsgi:application

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -1,9 +1,0 @@
-[uwsgi]
-chdir=/app
-socket=127.0.0.1:4000
-module=blog_project.wsgi:application
-master=True
-pidfile=/tmp/project-master.pid
-vacuum=True
-max-requests=5000
-# daemonize=/var/log/uwsgi/blog_project.log


### PR DESCRIPTION
按照 @WPH95 的意见改进了一下 Dockerfile 以及部署相关的配置。

## 数据管理
启动容器时挂载一个数据卷，并将数据库文件放入其中，这样可以实现数据持久化。设置环境变量 `DATA_PATH` 的值来改变容器内 SQLite 数据库文件的位置。
将实体机的数据目录挂载进容器，并运行：
```bash
docker run -d -p 8080:4000 -v "/path/to/your/data" imagename
```

## 部署相关
__以下内容同样适用于普通开发环境__
这个镜像用 Gunicorn 替代了 uWSGI 并去除了 NGINX。没有 NGINX 做转发，静态文件的处理就交给了 Django 。因此运行服务器前，我们不仅要迁移数据库，还要整理静态文件方便路由。
```bash
cd DjangoBlog

# 数据库迁移
python3 manage.py makemigrations
python3 manage.py migrate

# 整理静态文件
python3 manage.py collectstatic
```
然后 Django 就会把每个子目录下的 `static` 统一合并到项目根目录的 `static` 中。当然也可以直接调用运行脚本，迅速完成上面的任务并启动一个 Gunicorn 服务器：
```bash
cd DjangoBlog
./docker/start.sh
```
用浏览器打开 `http://localhost:4000` 即可。

## Dockerfile
我把 Python 包依赖的安装提前了，目的是减小镜像体积，并加快构建速度。

## 进程管理
运行这个镜像的容器正常状态下只有 Gunicorn 在工作，Gunicorn 一旦挂掉，启动进程就会退出。设置 `docker run` 的 `restart` 参数就可以实现容器自动重启，所以我觉得暂时不需要额外的进程管理工具。

有点语无伦次，请见谅 :)
